### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -10,7 +10,7 @@ SET(SOURCES
 )
 
 # PyBind
-add_subdirectory(pybind11)
+find_package(pybind11 REQUIRED)
 pybind11_add_module(${PROJECT_NAME}_python ${SOURCES})
 
 # Link OpenVSLAM_python

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,6 +11,7 @@ SET(SOURCES
 
 # PyBind
 find_package(pybind11 REQUIRED)
+include_directories(${pybind11_INCLUDE_DIR})
 pybind11_add_module(${PROJECT_NAME}_python ${SOURCES})
 
 # Link OpenVSLAM_python


### PR DESCRIPTION
Got a CMake error that Pybind11 subdirectory could not be found. 
I just did a fresh git clone and pybind11 is not included. It is correctly installed in conda, but CMake was looking in the wrong place.

Added this to fix it to the CMakeLists.txt:

find_package(pybind11 REQUIRED)